### PR TITLE
fix: remove config arg for Qwen2.5-7B-Instruct-Lora

### DIFF
--- a/models/Qwen2.5/05-Qwen2.5-7B-Instruct Lora 微调.md
+++ b/models/Qwen2.5/05-Qwen2.5-7B-Instruct Lora 微调.md
@@ -192,7 +192,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_path)
 model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto",torch_dtype=torch.bfloat16)
 
 # 加载lora权重
-model = PeftModel.from_pretrained(model, model_id=lora_path, config=config)
+model = PeftModel.from_pretrained(model, model_id=lora_path)
 
 prompt = "你是谁？"
 messages = [


### PR DESCRIPTION
models/Qwen2.5/05-Qwen2.5-7B-Instruct Lora 微调.md 中加载 LoRA 权重的时候，`config` 参数未定义且不必要，将其删除。