### PR TITLE
feat: 添加BGE-M3 MTEB变量

### DIFF
--- a/models/BGE-M3-finetune-embedding-with-valid/02-C-MTEB_retrieval_evaluation.ipynb
+++ b/models/BGE-M3-finetune-embedding-with-valid/02-C-MTEB_retrieval_evaluation.ipynb
@@ -881,6 +881,60 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "总共有 20 个评估指标\n",
+      "指标列表：\n",
+      " 1. ndcg_at_1\n",
+      " 2. ndcg_at_3\n",
+      " 3. ndcg_at_5\n",
+      " 4. ndcg_at_10\n",
+      " 5. map_at_1\n",
+      " 6. map_at_3\n",
+      " 7. map_at_5\n",
+      " 8. map_at_10\n",
+      " 9. recall_at_1\n",
+      "10. recall_at_3\n",
+      "11. recall_at_5\n",
+      "12. recall_at_10\n",
+      "13. precision_at_1\n",
+      "14. precision_at_3\n",
+      "15. precision_at_5\n",
+      "16. precision_at_10\n",
+      "17. mrr_at_1\n",
+      "18. mrr_at_3\n",
+      "19. mrr_at_5\n",
+      "20. mrr_at_10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 提取两个模型的评测结果\n",
+    "scores_m3 = all_results[\"BGE-M3\"][0].scores['dev'][0]\n",
+    "scores_reranker = all_results[\"BGE-M3-Finetuned\"][0].scores['dev'][0]\n",
+    "\n",
+    "# 完整的评估指标列表\n",
+    "metrics = [\n",
+    "    'ndcg_at_1', 'ndcg_at_3', 'ndcg_at_5', 'ndcg_at_10',\n",
+    "    'map_at_1', 'map_at_3', 'map_at_5', 'map_at_10', \n",
+    "    'recall_at_1', 'recall_at_3', 'recall_at_5', 'recall_at_10',\n",
+    "    'precision_at_1', 'precision_at_3', 'precision_at_5', 'precision_at_10',\n",
+    "    'mrr_at_1', 'mrr_at_3', 'mrr_at_5', 'mrr_at_10'\n",
+    "]\n",
+    "\n",
+    "print(f\"总共有 {len(metrics)} 个评估指标\")\n",
+    "print(\"指标列表：\")\n",
+    "for i, metric in enumerate(metrics, 1):\n",
+    "    print(f\"{i:2d}. {metric}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
「微调前后在C-MTEB上的评估结果」中，这三个变量没有定义
<img width="1664" height="806" alt="d3f4072d8aee6c10f31b255c259c7440" src="https://github.com/user-attachments/assets/7ed9c6a1-0477-415b-bca3-15b6523bfdcf" />

按文档中的指标做了定义，方便运行：
<img width="1592" height="832" alt="1dcc01bb48bd160e20475c1cf2f6526d" src="https://github.com/user-attachments/assets/a39e3ae9-d6f4-45c5-8287-97c900b63190" />
