### PR TITLE
docs: 新增 MiniMax-M2.5 部署教程（vLLM/SGLang/Transformers）

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
       • <a href="./support_model.md#step-35-flash">Step-3.5-Flash</a><br>
       • <a href="./support_model.md#glm-47-flash">GLM-4.7-Flash</a><br>
       • <a href="./support_model.md#gemma3">Gemma3</a><br>
+      • <a href="./support_model.md#minimax-m25">MiniMax-M2.5</a><br>
       • <a href="./support_model.md#minimax-m2">MiniMax-M2</a><br>
       • <a href="./support_model.md#qwen3">Qwen3</a><br>
       • <a href="./support_model.md#qwen3-vl-4b-instruct">Qwen3-VL</a><br>

--- a/models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md
+++ b/models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md
@@ -50,7 +50,7 @@ pip install modelscope
 python model_download.py
 ```
 
-> 注意：模型权重很大，若网络受限，可设置 HuggingFace 镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是让 vLLM 自动从 Hugging Face 拉取，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
 
 ## 启动 vLLM 服务
 
@@ -280,7 +280,11 @@ export HF_ENDPOINT=https://hf-mirror.com
 
 ### MiniMax-M2 model is not currently supported
 
-该 vLLM 版本过旧，请升级到最新版本。
+该 vLLM 版本过旧，请升级到最新版本：
+
+```bash
+pip install -U vllm
+```
 
 ### torch.AcceleratorError: CUDA error
 

--- a/models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md
+++ b/models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md
@@ -1,0 +1,298 @@
+# MiniMax-M2.5 vLLM 部署调用
+
+## MiniMax-M2.5 简介
+
+[MiniMax-M2.5](https://github.com/MiniMax-AI/MiniMax-M2.5) 是 MiniMax 推出的最新一代开源大语言模型。M2.5 通过在数十万个复杂真实场景中进行强化学习训练，在代码、Agent 工具调用与搜索、办公等多项经济价值任务中达到 SOTA 水平，包括 SWE-Bench Verified 80.2%、Multi-SWE-Bench 51.3%、BrowseComp 76.3% 等优异成绩。
+
+M2.5 兼具高效与低成本——以 100 token/s 的速度连续运行一小时仅需 1 美元。本文以 MiniMax-M2.5 为模型基座，演示如何通过 vLLM 完成模型下载、服务启动与客户端调用。
+
+## vLLM 简介
+
+`vLLM` 是一个面向大语言模型的高性能部署推理框架，提供开箱即用的推理加速与 OpenAI 兼容接口。它支持长上下文推理、流式输出、多卡并行（如张量并行与专家并行）、工具调用与"思考内容"解析等能力，便于将最新模型快速落地到生产环境。
+
+## 环境准备
+
+基础环境（参考值）：
+
+> 可用 `nvidia-smi` 与 `python -c "import torch;print(torch.cuda.is_available())"` 自检 CUDA / PyTorch。
+
+显存与推荐配置（按官方文档）：
+- 权重需求约 220 GB 显存；每 1M 上下文 token 约需 240 GB 显存
+- 96G × 4 GPU：支持约 40 万 token 总上下文
+- 144G × 8 GPU：支持约 300 万 token 总上下文
+
+> **注**：以上数值为硬件支持的最大并发缓存总量，模型单序列（Single Sequence）长度上限为 196k。
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install vllm --torch-backend=auto
+```
+
+## 模型下载
+
+vLLM 会在首次启动时自动从 Hugging Face 拉取并缓存模型，无需手动下载。若希望提前下载或受网络限制，可选用 `modelscope` 手动下载模型：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M2.5', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 注意：模型权重很大，若网络受限，可设置 HuggingFace 镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 启动 vLLM 服务
+
+### Python 启动脚本
+
+新建 `start_server.py`：
+
+```python
+import torch
+from vllm.utils import launch_server_cmd, wait_for_server
+
+gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+if gpu_count == 4:
+    cmd = (
+        "SAFETENSORS_FAST_GPU=1 vllm serve "
+        "MiniMaxAI/MiniMax-M2.5 --trust-remote-code "
+        "--tensor-parallel-size 4 "
+        "--enable-auto-tool-choice --tool-call-parser minimax_m2 "
+        "--reasoning-parser minimax_m2_append_think"
+    )
+elif gpu_count == 8:
+    cmd = (
+        "SAFETENSORS_FAST_GPU=1 vllm serve "
+        "MiniMaxAI/MiniMax-M2.5 --trust-remote-code "
+        "--enable_expert_parallel --tensor-parallel-size 8 "
+        "--enable-auto-tool-choice --tool-call-parser minimax_m2 "
+        "--reasoning-parser minimax_m2_append_think"
+    )
+else:
+    raise RuntimeError(f"建议使用 4 或 8 张 GPU，当前检测到: {gpu_count}")
+
+server_process, port = launch_server_cmd(cmd, port=8000)
+wait_for_server(f"http://127.0.0.1:{port}")
+print(f"vLLM Server started: http://127.0.0.1:{port}")
+```
+
+启动：
+
+```bash
+python start_server.py
+```
+
+服务启动成功后将监听 `http://127.0.0.1:8000/v1`。
+
+### 命令行直接启动
+
+4 卡部署：
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M2.5 --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+8 卡部署：
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M2.5 --trust-remote-code \
+    --enable_expert_parallel --tensor-parallel-size 8 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+> 由于模型较大，首次加载时间较长，可能需要半小时以上。
+
+> 如遇到 CUDA 内存错误，可在启动参数中添加 `--compilation-config "{\"cudagraph_mode\": \"PIECEWISE\"}"` 解决。
+
+## curl 测试
+
+使用 curl 调用 OpenAI 兼容接口：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-M2.5",
+    "messages": [
+      {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+      {"role": "user", "content": [{"type": "text", "text": "请简要介绍 MiniMax-M2.5 模型的特点。"}]}
+    ]
+  }'
+```
+
+## 调用示例
+
+以下示例均使用 OpenAI 官方 Python SDK 调用 vLLM 的 OpenAI 兼容接口。
+
+### 聊天对话（Chat Completions）
+
+```python
+# test_chat.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M2.5",
+    messages=[
+        {"role": "user", "content": "请介绍 MiniMax-M2.5 模型相比 M2 有哪些提升？"}
+    ],
+    max_tokens=8192,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+msg = response.choices[0].message
+print("MiniMax-M2.5:", msg.content)
+```
+
+运行：
+
+```bash
+python test_chat.py
+```
+
+### 流式输出（Streaming）
+
+```python
+# test_streaming.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M2.5",
+    messages=[{"role": "user", "content": "请用 Python 写一个快速排序算法，并附带详细注释。"}],
+    stream=True,
+    max_tokens=32768,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta and delta.content:
+        print(delta.content, end="", flush=True)
+```
+
+运行：
+
+```bash
+python test_streaming.py
+```
+
+### 工具调用（Tool Calling）
+
+MiniMax-M2.5 在 Agent 和工具调用方面表现出色，能够稳定执行复杂长链条工具调用任务。在 vLLM 部署时通过 `--enable-auto-tool-choice --tool-call-parser minimax_m2` 启用工具调用功能。
+
+```python
+# test_tool_calling.py
+from openai import OpenAI
+import json
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+def get_weather(location: str, unit: str):
+    return f"Getting the weather for {location} in {unit}..."
+
+tool_functions = {"get_weather": get_weather}
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City and state, e.g., 'San Francisco, CA'"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location", "unit"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model=client.models.list().data[0].id,
+    messages=[{"role": "user", "content": "北京今天天气怎么样？请用摄氏度。"}],
+    tools=tools,
+    tool_choice="auto"
+)
+
+tool_call = response.choices[0].message.tool_calls[0].function
+print(f"Function called: {tool_call.name}")
+print(f"Arguments: {tool_call.arguments}")
+print(f"Result: {get_weather(**json.loads(tool_call.arguments))}")
+```
+
+运行：
+
+```bash
+python test_tool_calling.py
+```
+
+## 参数说明与建议
+
+- `model`：启动时指定的模型名称或本地路径（例：`MiniMaxAI/MiniMax-M2.5`）；OpenAI 请求中的 `model` 需与之对应。
+- `--tensor-parallel-size`：张量并行大小，常设为 GPU 数量（4 或 8）。
+- `--enable_expert_parallel`：启用专家并行（8 卡示例中开启）。
+- `--enable-auto-tool-choice`：自动工具选择（使模型在需要时自主发起工具调用）。
+- `--tool-call-parser minimax_m2`：启用 MiniMax 的工具调用解析。
+- `--reasoning-parser minimax_m2_append_think`：启用思考内容解析（将 reasoning 以追加方式处理）。
+- `max_tokens`：控制生成长度；过大将增加显存和时延。
+- `temperature`/`top_p`：控制多样性。官方推荐参数：temperature=1.0, top_p=0.95, top_k=20。
+
+> 显存建议：M2.5 权重约 220 GB；每 1M 上下文约 240 GB。请结合业务并发与上下文需求评估资源。
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+如果遇到网络问题，可设置镜像后再进行拉取：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+### MiniMax-M2 model is not currently supported
+
+该 vLLM 版本过旧，请升级到最新版本。
+
+### torch.AcceleratorError: CUDA error
+
+在启动参数添加 `--compilation-config "{\"cudagraph_mode\": \"PIECEWISE\"}"` 可以解决。
+
+### 模型输出乱码
+
+请升级到最新版本的 vLLM（至少确保版本在提交 [cf3eacfe](https://github.com/vllm-project/vllm/commit/cf3eacfe58fa9e745c2854782ada884a9f992cf7) 之后）。
+
+## 参考链接
+
+- [MiniMax-M2.5 GitHub](https://github.com/MiniMax-AI/MiniMax-M2.5)
+- [MiniMax-M2.5 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
+- [MiniMax-M2.5 官方 vLLM 部署指南](https://github.com/MiniMax-AI/MiniMax-M2.5/blob/main/docs/vllm_deploy_guide_cn.md)
+- [vLLM 官方文档](https://docs.vllm.ai/en/stable/)

--- a/models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md
+++ b/models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md
@@ -1,0 +1,306 @@
+# MiniMax-M2.5 SGLang 部署调用
+
+## MiniMax-M2.5 简介
+
+[MiniMax-M2.5](https://github.com/MiniMax-AI/MiniMax-M2.5) 是 MiniMax 推出的最新一代开源大语言模型。M2.5 通过在数十万个复杂真实场景中进行强化学习训练，在代码（SWE-Bench Verified 80.2%）、Agent 工具调用与搜索（BrowseComp 76.3%）、办公等多项任务中达到 SOTA 水平，同时兼具高效与低成本特性。
+
+本文以 MiniMax-M2.5 为模型基座，演示如何通过 SGLang 完成模型下载、服务启动与客户端调用。
+
+## SGLang 简介
+
+`SGLang` 是一个面向大语言模型的高性能部署推理框架，提供开箱即用的推理加速与 OpenAI 兼容接口。它支持长上下文推理、流式输出、多卡并行（如张量并行与专家并行）、工具调用与"思考内容"解析等能力，便于将最新模型快速落地到生产环境。
+
+## 环境准备
+
+基础环境（参考值）：
+
+> 可用 `nvidia-smi` 与 `python -c "import torch;print(torch.version.cuda, torch.cuda.is_available())"` 自检 CUDA / PyTorch。
+
+显存与推荐配置（按官方文档）：
+- 权重需求约 220 GB 显存；每 1M 上下文 token 约需 240 GB 显存
+- 96G × 4 GPU：支持约 40 万 token 总上下文
+- 144G × 8 GPU：支持约 300 万 token 总上下文
+
+> **注**：以上数值为硬件支持的最大并发缓存总量，模型单序列（Single Sequence）长度上限为 196k。
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install sglang
+```
+
+> 请确保 SGLang 版本 >= v0.5.4.post1，以获得对 MiniMax 模型的完整支持。
+
+## 模型下载
+
+SGLang 会在首次启动时自动从 Hugging Face 拉取并缓存模型，无需手动下载。若希望提前下载或受网络限制，可选用 `modelscope` 手动下载模型：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M2.5', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 注意：模型权重很大，若网络受限，可设置 HuggingFace 镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 启动 SGLang 服务
+
+### Python 启动脚本
+
+新建 `start_server.py`：
+
+```python
+import torch
+from sglang.utils import launch_server_cmd, wait_for_server
+
+gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+if gpu_count == 4:
+    cmd = (
+        "python -m sglang.launch_server "
+        "--model-path MiniMaxAI/MiniMax-M2.5 "
+        "--host 0.0.0.0 "
+        "--port 8000 "
+        "--tp-size 4 "
+        "--tool-call-parser minimax-m2 "
+        "--reasoning-parser minimax-append-think "
+        "--trust-remote-code "
+        "--mem-fraction-static 0.85"
+    )
+elif gpu_count == 8:
+    cmd = (
+        "python -m sglang.launch_server "
+        "--model-path MiniMaxAI/MiniMax-M2.5 "
+        "--host 0.0.0.0 "
+        "--port 8000 "
+        "--tp-size 8 "
+        "--ep-size 8 "
+        "--tool-call-parser minimax-m2 "
+        "--reasoning-parser minimax-append-think "
+        "--trust-remote-code "
+        "--mem-fraction-static 0.85"
+    )
+else:
+    raise RuntimeError(f"建议使用 4 或 8 张 GPU，当前检测到: {gpu_count}")
+
+server_process, port = launch_server_cmd(cmd, port=8000)
+wait_for_server(f"http://127.0.0.1:{port}")
+print(f"SGLang Server started: http://127.0.0.1:{port}")
+```
+
+启动：
+
+```bash
+python start_server.py
+```
+
+服务启动成功后将监听 `http://127.0.0.1:8000/v1`。
+
+### 命令行直接启动
+
+4 卡部署：
+
+```bash
+python -m sglang.launch_server \
+  --model-path MiniMaxAI/MiniMax-M2.5 \
+  --tp-size 4 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --host 0.0.0.0 \
+  --trust-remote-code \
+  --port 8000 \
+  --mem-fraction-static 0.85
+```
+
+8 卡部署：
+
+```bash
+python -m sglang.launch_server \
+  --model-path MiniMaxAI/MiniMax-M2.5 \
+  --tp-size 8 \
+  --ep-size 8 \
+  --tool-call-parser minimax-m2 \
+  --trust-remote-code \
+  --host 0.0.0.0 \
+  --reasoning-parser minimax-append-think \
+  --port 8000 \
+  --mem-fraction-static 0.85
+```
+
+> 由于模型较大，首次加载时间较长，可能需要半小时以上。
+
+## curl 测试
+
+使用 curl 调用 OpenAI 兼容接口：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-M2.5",
+    "messages": [
+      {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+      {"role": "user", "content": [{"type": "text", "text": "请简要介绍 MiniMax-M2.5 模型的特点。"}]}
+    ]
+  }'
+```
+
+## 调用示例
+
+以下示例均使用 OpenAI 官方 Python SDK 调用 SGLang 的 OpenAI 兼容接口。
+
+### 聊天对话（Chat Completions）
+
+```python
+# test_chat.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M2.5",
+    messages=[
+        {"role": "user", "content": "请介绍 MiniMax-M2.5 模型相比 M2 有哪些提升？"}
+    ],
+    max_tokens=8192,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+msg = response.choices[0].message
+print("MiniMax-M2.5:", msg.content)
+```
+
+运行：
+
+```bash
+python test_chat.py
+```
+
+### 流式输出（Streaming）
+
+```python
+# test_streaming.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M2.5",
+    messages=[{"role": "user", "content": "请用 Python 实现一个二叉搜索树，包含插入、查找和删除操作。"}],
+    stream=True,
+    max_tokens=32768,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta and delta.content:
+        print(delta.content, end="", flush=True)
+```
+
+运行：
+
+```bash
+python test_streaming.py
+```
+
+### 工具调用（Tool Calling）
+
+MiniMax-M2.5 在 Agent 和工具调用方面表现出色。在 SGLang 部署时通过 `--tool-call-parser minimax-m2` 启用工具调用功能。
+
+```python
+# test_tool_calling.py
+from openai import OpenAI
+import json
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+def get_weather(location: str, unit: str):
+    return f"Getting the weather for {location} in {unit}..."
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City and state, e.g., 'San Francisco, CA'"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location", "unit"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model=client.models.list().data[0].id,
+    messages=[{"role": "user", "content": "北京今天天气怎么样？请用摄氏度。"}],
+    tools=tools,
+    tool_choice="auto"
+)
+
+tool_call = response.choices[0].message.tool_calls[0].function
+print(f"Function called: {tool_call.name}")
+print(f"Arguments: {tool_call.arguments}")
+print(f"Result: {get_weather(**json.loads(tool_call.arguments))}")
+```
+
+运行：
+
+```bash
+python test_tool_calling.py
+```
+
+## 参数说明与建议
+
+- `--model-path`：模型名称或本地路径（例：`MiniMaxAI/MiniMax-M2.5`）。
+- `--tp-size`：张量并行大小，常设为 GPU 数量（4 或 8）。
+- `--ep-size`：专家并行大小（8 卡示例中开启）。
+- `--tool-call-parser minimax-m2`：启用 MiniMax 的工具调用解析。
+- `--reasoning-parser minimax-append-think`：启用思考内容解析。
+- `--mem-fraction-static`：静态显存比例，显存紧张时可适当调低。
+- `--trust-remote-code`：信任远程代码（MiniMax 模型需要此参数）。
+- 官方推荐采样参数：temperature=1.0, top_p=0.95, top_k=20。
+
+> 显存建议：M2.5 权重约 220 GB；每 1M 上下文约 240 GB。请结合业务并发与上下文需求评估资源。
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+如果遇到网络问题，可设置镜像后再进行拉取：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+### MiniMax-M2 model is not currently supported
+
+请升级到最新的稳定版本，需 >= v0.5.4.post1。
+
+## 参考链接
+
+- [MiniMax-M2.5 GitHub](https://github.com/MiniMax-AI/MiniMax-M2.5)
+- [MiniMax-M2.5 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
+- [MiniMax-M2.5 官方 SGLang 部署指南](https://github.com/MiniMax-AI/MiniMax-M2.5/blob/main/docs/sglang_deploy_guide_cn.md)
+- [SGLang 官方文档](https://github.com/sgl-project/sglang)

--- a/models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md
+++ b/models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md
@@ -33,7 +33,7 @@ source .venv/bin/activate
 uv pip install sglang
 ```
 
-> 请确保 SGLang 版本 >= v0.5.4.post1，以获得对 MiniMax 模型的完整支持。
+> 请确保 SGLang 版本 >= v0.5.4.post1，以获得对 MiniMax 模型的完整支持。可使用 `pip show sglang` 查看当前安装的版本。
 
 ## 模型下载
 
@@ -52,7 +52,7 @@ pip install modelscope
 python model_download.py
 ```
 
-> 注意：模型权重很大，若网络受限，可设置 HuggingFace 镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是让 SGLang 自动从 Hugging Face 拉取，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
 
 ## 启动 SGLang 服务
 
@@ -296,7 +296,11 @@ export HF_ENDPOINT=https://hf-mirror.com
 
 ### MiniMax-M2 model is not currently supported
 
-请升级到最新的稳定版本，需 >= v0.5.4.post1。
+请升级到最新的稳定版本，需 >= v0.5.4.post1：
+
+```bash
+pip install -U sglang
+```
 
 ## 参考链接
 

--- a/models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md
+++ b/models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md
@@ -40,7 +40,7 @@ pip install modelscope
 python model_download.py
 ```
 
-> 网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是直接通过 Transformers 从 Hugging Face 下载，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
 
 ## 推理示例
 
@@ -129,13 +129,21 @@ python test_multi_turn.py
 
 ### Hugging Face 网络问题
 
+若未使用 `modelscope` 下载模型，而是直接通过 Transformers 从 Hugging Face 下载，可设置镜像：
+
 ```bash
 export HF_ENDPOINT=https://hf-mirror.com
 ```
 
+> 若已通过 `modelscope` 下载模型并指定了本地路径，则无需此设置。
+
 ### MiniMax-M2 model is not currently supported
 
-请确认已开启 `trust_remote_code=True`，并升级 Transformers 至 >= 4.57.1。
+请确认已开启 `trust_remote_code=True`，并升级 Transformers 至 >= 4.57.1：
+
+```bash
+pip install -U transformers
+```
 
 ## 参考链接
 

--- a/models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md
+++ b/models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md
@@ -1,0 +1,144 @@
+# MiniMax-M2.5 Transformers 部署调用
+
+## MiniMax-M2.5 简介
+
+[MiniMax-M2.5](https://github.com/MiniMax-AI/MiniMax-M2.5) 是 MiniMax 推出的最新一代开源大语言模型，在代码、Agent 工具调用与搜索、办公等多项任务中达到 SOTA 水平。本文演示如何通过 Transformers 直接加载并运行 MiniMax-M2.5 模型。
+
+## 环境准备
+
+基础环境（参考值）：
+
+- OS：Linux
+- Python：3.9 - 3.12
+- Transformers：>= 4.57.1
+- GPU：compute capability 7.0 or higher，显存需求约 220 GB
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install transformers==4.57.1 torch accelerate --torch-backend=auto
+```
+
+## 模型下载
+
+Transformers 会在首次加载时自动从 Hugging Face 下载并缓存模型。若网络受限，可使用 `modelscope` 提前下载：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M2.5', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 推理示例
+
+### 基础对话
+
+```python
+# test_transformers.py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+MODEL_PATH = "MiniMaxAI/MiniMax-M2.5"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_PATH,
+    device_map="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+messages = [
+    {"role": "user", "content": [{"type": "text", "text": "请介绍一下 MiniMax-M2.5 模型的主要特点。"}]},
+]
+
+model_inputs = tokenizer.apply_chat_template(
+    messages, return_tensors="pt", add_generation_prompt=True
+).to("cuda")
+
+generated_ids = model.generate(
+    model_inputs,
+    max_new_tokens=2048,
+    generation_config=model.generation_config,
+)
+
+response = tokenizer.batch_decode(generated_ids)[0]
+print(response)
+```
+
+运行：
+
+```bash
+python test_transformers.py
+```
+
+### 多轮对话
+
+```python
+# test_multi_turn.py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_PATH = "MiniMaxAI/MiniMax-M2.5"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_PATH,
+    device_map="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+messages = [
+    {"role": "user", "content": [{"type": "text", "text": "什么是快速排序？"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "快速排序是一种高效的排序算法，采用分治策略，通过选择一个基准元素将数组分为两部分，然后递归排序。"}]},
+    {"role": "user", "content": [{"type": "text", "text": "请用 Python 实现它。"}]},
+]
+
+model_inputs = tokenizer.apply_chat_template(
+    messages, return_tensors="pt", add_generation_prompt=True
+).to("cuda")
+
+generated_ids = model.generate(
+    model_inputs,
+    max_new_tokens=2048,
+    generation_config=model.generation_config,
+)
+
+response = tokenizer.batch_decode(generated_ids)[0]
+print(response)
+```
+
+运行：
+
+```bash
+python test_multi_turn.py
+```
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+### MiniMax-M2 model is not currently supported
+
+请确认已开启 `trust_remote_code=True`，并升级 Transformers 至 >= 4.57.1。
+
+## 参考链接
+
+- [MiniMax-M2.5 GitHub](https://github.com/MiniMax-AI/MiniMax-M2.5)
+- [MiniMax-M2.5 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
+- [MiniMax-M2.5 官方 Transformers 部署指南](https://github.com/MiniMax-AI/MiniMax-M2.5/blob/main/docs/transformers_deploy_guide_cn.md)

--- a/support_model.md
+++ b/support_model.md
@@ -8,6 +8,7 @@
 - [Step-3.5-Flash](#step-35-flash)
 - [GLM-4.7-Flash](#glm-47-flash)
 - [谷歌-Gemma3](#谷歌-gemma3)
+- [MiniMax-M2.5](#minimax-m25)
 - [MiniMax-M2](#minimax-m2)
 - [Qwen3-VL-4B-Instruct](#qwen3-vl-4b-instruct)
 - [BGE-M3](#bge-m3)
@@ -90,6 +91,16 @@
 - [x] [gemma-2b-it Peft Lora 微调 ](./models/Gemma/04-Gemma-2B-Instruct%20Lora微调.md) @陈榆
 - [X] [gemma3-4b-it AMD 环境准备](./models/Gemma3/7-gemma3-4b-it%20AMD环境准备.md) @陈榆
 - [X] [gemma3-4b-it AMD 模型服务部署](./models/Gemma3/8-gemma3-4b-it%20模型服务部署.md) @陈榆
+
+### MiniMax-M2.5
+
+[MiniMax-M2.5](https://github.com/MiniMax-AI/MiniMax-M2.5)
+- [x] [MiniMax-M2.5 在线体验地址](https://agent.minimax.io/)
+- [x] [MiniMax-M2.5 Hugging Face 地址](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
+- [x] [MiniMax-M2.5 Text Generation Guide](https://platform.minimax.io/docs/guides/text-generation)
+- [x] [MiniMax-M2.5 vLLM 部署调用](./models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md)
+- [x] [MiniMax-M2.5 SGLang 部署调用](./models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md)
+- [x] [MiniMax-M2.5 Transformers 部署调用](./models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md)
 
 ### MiniMax-M2
 


### PR DESCRIPTION
## 新增 MiniMax-M2.5 部署教程

### 概要

新增 MiniMax-M2.5 模型的部署教程，包括 vLLM、SGLang 和 Transformers 三种部署方式的完整指南。

[MiniMax-M2.5](https://github.com/MiniMax-AI/MiniMax-M2.5) 是 MiniMax 推出的最新一代开源大语言模型，在多项基准测试中达到 SOTA 水平：
- SWE-Bench Verified: 80.2%
- Multi-SWE-Bench: 51.3%
- BrowseComp: 76.3%

### 变更内容

**新增文件：**
- `models/MiniMax-M2.5/1-MiniMax-M2.5-vLLM.md` - vLLM 部署调用教程
- `models/MiniMax-M2.5/2-MiniMax-M2.5-SGLang.md` - SGLang 部署调用教程
- `models/MiniMax-M2.5/3-MiniMax-M2.5-Transformers.md` - Transformers 部署调用教程

**修改文件：**
- `support_model.md` - 在已支持模型列表中添加 MiniMax-M2.5
- `README.md` - 在首页模型列表中添加 MiniMax-M2.5 链接

### 教程内容

每个部署教程均包含：
- 环境准备与依赖安装
- 模型下载（HuggingFace / ModelScope）
- 服务启动（Python 脚本 + 命令行两种方式）
- 调用示例（Chat、Streaming、Tool Calling）
- 参数说明与常见问题

教程格式与现有 MiniMax-M2 教程保持一致，内容基于 [MiniMax 官方部署指南](https://github.com/MiniMax-AI/MiniMax-M2.5/tree/main/docs) 编写。