### PR TITLE
docs: 新增 MiniMax-M3 部署教程（vLLM/SGLang/Transformers）

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
       • <a href="./support_model.md#step-35-flash">Step-3.5-Flash</a><br>
       • <a href="./support_model.md#glm-47-flash">GLM-4.7-Flash</a><br>
       • <a href="./support_model.md#gemma3">Gemma3</a><br>
+      • <a href="./support_model.md#minimax-m3">MiniMax-M3</a><br>
       • <a href="./support_model.md#minimax-m25">MiniMax-M2.5</a><br>
       • <a href="./support_model.md#minimax-m2">MiniMax-M2</a><br>
       • <a href="./support_model.md#qwen3">Qwen3</a><br>

--- a/README_en.md
+++ b/README_en.md
@@ -86,6 +86,7 @@
   <tr>
     <td valign="top" width="25%">
       • <a href="./support_model.md#gemma3">Gemma3</a><br>
+      • <a href="./support_model.md#minimax-m3">MiniMax-M3</a><br>
       • <a href="./support_model.md#minimax-m2">MiniMax-M2</a><br>
       • <a href="./support_model.md#qwen3">Qwen3</a><br>
       • <a href="./support_model.md#qwen3-vl-4b-instruct">Qwen3-VL</a><br>

--- a/models/MiniMax-M3/1-MiniMax-M3-vLLM.md
+++ b/models/MiniMax-M3/1-MiniMax-M3-vLLM.md
@@ -1,0 +1,335 @@
+# MiniMax-M3 vLLM 部署调用
+
+## MiniMax-M3 简介
+
+[MiniMax-M3](https://github.com/MiniMax-AI/MiniMax-M3) 是 MiniMax 推出的最新一代开源大语言模型。相较于 M2.5，M3 在长上下文、推理质量和多模态能力上均有明显提升：上下文窗口扩展到 **512K**、单次最大输出可达 **128K**，并原生支持**图片输入**（OpenAI 兼容与 Anthropic 兼容两套接口均可使用，目前仅图片，视频/音频/文档暂不支持）。
+
+本文以 MiniMax-M3 为模型基座，演示如何通过 vLLM 完成模型下载、服务启动与客户端调用（含图片输入）。
+
+## vLLM 简介
+
+`vLLM` 是一个面向大语言模型的高性能部署推理框架，提供开箱即用的推理加速与 OpenAI 兼容接口。它支持长上下文推理、流式输出、多卡并行（如张量并行与专家并行）、工具调用与"思考内容"解析等能力，便于将最新模型快速落地到生产环境。
+
+## 环境准备
+
+基础环境（参考值）：
+
+> 可用 `nvidia-smi` 与 `python -c "import torch;print(torch.cuda.is_available())"` 自检 CUDA / PyTorch。
+
+显存与推荐配置（按官方文档）：
+- 权重需求约 220 GB 显存；每 1M 上下文 token 约需 240 GB 显存
+- 96G × 4 GPU：支持约 40 万 token 总上下文
+- 144G × 8 GPU：支持约 300 万 token 总上下文
+
+> **注**：上下文窗口最大为 512K，单次最大输出为 128K；以上数值为硬件支持的最大并发缓存总量。
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install vllm --torch-backend=auto
+```
+
+> 请确保 vLLM 版本支持 MiniMax-M3。若启动时报模型不支持，请升级 `pip install -U vllm`。
+
+## 模型下载
+
+vLLM 会在首次启动时自动从 Hugging Face 拉取并缓存模型，无需手动下载。若希望提前下载或受网络限制，可选用 `modelscope` 手动下载模型：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M3', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是让 vLLM 自动从 Hugging Face 拉取，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 启动 vLLM 服务
+
+### Python 启动脚本
+
+新建 `start_server.py`：
+
+```python
+import torch
+from vllm.utils import launch_server_cmd, wait_for_server
+
+gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+if gpu_count == 4:
+    cmd = (
+        "SAFETENSORS_FAST_GPU=1 vllm serve "
+        "MiniMaxAI/MiniMax-M3 --trust-remote-code "
+        "--tensor-parallel-size 4 "
+        "--enable-auto-tool-choice --tool-call-parser minimax_m2 "
+        "--reasoning-parser minimax_m2_append_think"
+    )
+elif gpu_count == 8:
+    cmd = (
+        "SAFETENSORS_FAST_GPU=1 vllm serve "
+        "MiniMaxAI/MiniMax-M3 --trust-remote-code "
+        "--enable_expert_parallel --tensor-parallel-size 8 "
+        "--enable-auto-tool-choice --tool-call-parser minimax_m2 "
+        "--reasoning-parser minimax_m2_append_think"
+    )
+else:
+    raise RuntimeError(f"建议使用 4 或 8 张 GPU，当前检测到: {gpu_count}")
+
+server_process, port = launch_server_cmd(cmd, port=8000)
+wait_for_server(f"http://127.0.0.1:{port}")
+print(f"vLLM Server started: http://127.0.0.1:{port}")
+```
+
+启动：
+
+```bash
+python start_server.py
+```
+
+服务启动成功后将监听 `http://127.0.0.1:8000/v1`。
+
+### 命令行直接启动
+
+4 卡部署：
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M3 --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+8 卡部署：
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M3 --trust-remote-code \
+    --enable_expert_parallel --tensor-parallel-size 8 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+> 由于模型较大，首次加载时间较长，可能需要半小时以上。
+
+> 如遇到 CUDA 内存错误，可在启动参数中添加 `--compilation-config "{\"cudagraph_mode\": \"PIECEWISE\"}"` 解决。
+
+## curl 测试
+
+使用 curl 调用 OpenAI 兼容接口：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-M3",
+    "messages": [
+      {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+      {"role": "user", "content": [{"type": "text", "text": "请简要介绍 MiniMax-M3 模型的特点。"}]}
+    ]
+  }'
+```
+
+## 调用示例
+
+以下示例均使用 OpenAI 官方 Python SDK 调用 vLLM 的 OpenAI 兼容接口。
+
+### 聊天对话（Chat Completions）
+
+```python
+# test_chat.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[
+        {"role": "user", "content": "请介绍 MiniMax-M3 相比 M2.5 有哪些提升？"}
+    ],
+    max_tokens=8192,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+msg = response.choices[0].message
+print("MiniMax-M3:", msg.content)
+```
+
+运行：
+
+```bash
+python test_chat.py
+```
+
+### 流式输出（Streaming）
+
+```python
+# test_streaming.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[{"role": "user", "content": "请用 Python 写一个快速排序算法，并附带详细注释。"}],
+    stream=True,
+    max_tokens=32768,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta and delta.content:
+        print(delta.content, end="", flush=True)
+```
+
+运行：
+
+```bash
+python test_streaming.py
+```
+
+### 图片输入（Vision）
+
+MiniMax-M3 原生支持图片输入。在 OpenAI 兼容接口中，将 `image_url` 与文本一起放入 `content` 数组即可：
+
+```python
+# test_vision.py
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:8000/v1")
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "请描述这张图片中的内容。"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg"},
+                },
+            ],
+        }
+    ],
+    max_tokens=4096,
+)
+print(response.choices[0].message.content)
+```
+
+> 仅支持图片输入；视频、音频、文档暂不支持。
+
+### 工具调用（Tool Calling）
+
+MiniMax-M3 在 Agent 和工具调用方面继续保持强表现，能够稳定执行复杂长链条工具调用任务。在 vLLM 部署时通过 `--enable-auto-tool-choice --tool-call-parser minimax_m2` 启用工具调用功能。
+
+```python
+# test_tool_calling.py
+from openai import OpenAI
+import json
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+def get_weather(location: str, unit: str):
+    return f"Getting the weather for {location} in {unit}..."
+
+tool_functions = {"get_weather": get_weather}
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City and state, e.g., 'San Francisco, CA'"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location", "unit"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model=client.models.list().data[0].id,
+    messages=[{"role": "user", "content": "北京今天天气怎么样？请用摄氏度。"}],
+    tools=tools,
+    tool_choice="auto"
+)
+
+tool_call = response.choices[0].message.tool_calls[0].function
+print(f"Function called: {tool_call.name}")
+print(f"Arguments: {tool_call.arguments}")
+print(f"Result: {get_weather(**json.loads(tool_call.arguments))}")
+```
+
+运行：
+
+```bash
+python test_tool_calling.py
+```
+
+## 参数说明与建议
+
+- `model`：启动时指定的模型名称或本地路径（例：`MiniMaxAI/MiniMax-M3`）；OpenAI 请求中的 `model` 需与之对应。
+- `--tensor-parallel-size`：张量并行大小，常设为 GPU 数量（4 或 8）。
+- `--enable_expert_parallel`：启用专家并行（8 卡示例中开启）。
+- `--enable-auto-tool-choice`：自动工具选择（使模型在需要时自主发起工具调用）。
+- `--tool-call-parser minimax_m2`：启用 MiniMax 的工具调用解析。
+- `--reasoning-parser minimax_m2_append_think`：启用思考内容解析（将 reasoning 以追加方式处理）。
+- `max_tokens`：控制生成长度，M3 支持最大 128K 输出；过大将增加显存和时延。
+- `temperature`/`top_p`：控制多样性。官方推荐参数：temperature=1.0, top_p=0.95, top_k=20。
+
+> 显存建议：M3 权重约 220 GB；每 1M 上下文约 240 GB。请结合业务并发与上下文需求评估资源。
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+如果遇到网络问题，可设置镜像后再进行拉取：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+### MiniMax-M3 model is not currently supported
+
+该 vLLM 版本过旧，请升级到最新版本：
+
+```bash
+pip install -U vllm
+```
+
+### torch.AcceleratorError: CUDA error
+
+在启动参数添加 `--compilation-config "{\"cudagraph_mode\": \"PIECEWISE\"}"` 可以解决。
+
+### 模型输出乱码
+
+请升级到最新版本的 vLLM，并确保使用与 MiniMax-M3 适配的版本。
+
+## 参考链接
+
+- [MiniMax-M3 GitHub](https://github.com/MiniMax-AI/MiniMax-M3)
+- [MiniMax-M3 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M3)
+- [MiniMax 平台文档](https://platform.minimax.io/docs/guides/text-generation)
+- [vLLM 官方文档](https://docs.vllm.ai/en/stable/)

--- a/models/MiniMax-M3/2-MiniMax-M3-SGLang.md
+++ b/models/MiniMax-M3/2-MiniMax-M3-SGLang.md
@@ -1,0 +1,342 @@
+# MiniMax-M3 SGLang 部署调用
+
+## MiniMax-M3 简介
+
+[MiniMax-M3](https://github.com/MiniMax-AI/MiniMax-M3) 是 MiniMax 推出的最新一代开源大语言模型。相较于 M2.5，M3 在长上下文、推理质量和多模态能力上均有明显提升：上下文窗口扩展到 **512K**、单次最大输出可达 **128K**，并原生支持**图片输入**（OpenAI 兼容与 Anthropic 兼容两套接口均可使用，目前仅图片，视频/音频/文档暂不支持）。
+
+本文以 MiniMax-M3 为模型基座，演示如何通过 SGLang 完成模型下载、服务启动与客户端调用（含图片输入）。
+
+## SGLang 简介
+
+`SGLang` 是一个面向大语言模型的高性能部署推理框架，提供开箱即用的推理加速与 OpenAI 兼容接口。它支持长上下文推理、流式输出、多卡并行（如张量并行与专家并行）、工具调用与"思考内容"解析等能力，便于将最新模型快速落地到生产环境。
+
+## 环境准备
+
+基础环境（参考值）：
+
+> 可用 `nvidia-smi` 与 `python -c "import torch;print(torch.version.cuda, torch.cuda.is_available())"` 自检 CUDA / PyTorch。
+
+显存与推荐配置（按官方文档）：
+- 权重需求约 220 GB 显存；每 1M 上下文 token 约需 240 GB 显存
+- 96G × 4 GPU：支持约 40 万 token 总上下文
+- 144G × 8 GPU：支持约 300 万 token 总上下文
+
+> **注**：上下文窗口最大为 512K，单次最大输出为 128K；以上数值为硬件支持的最大并发缓存总量。
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install sglang
+```
+
+> 请确保 SGLang 版本支持 MiniMax-M3，可使用 `pip show sglang` 查看当前安装的版本，必要时升级。
+
+## 模型下载
+
+SGLang 会在首次启动时自动从 Hugging Face 拉取并缓存模型，无需手动下载。若希望提前下载或受网络限制，可选用 `modelscope` 手动下载模型：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M3', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是让 SGLang 自动从 Hugging Face 拉取，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 启动 SGLang 服务
+
+### Python 启动脚本
+
+新建 `start_server.py`：
+
+```python
+import torch
+from sglang.utils import launch_server_cmd, wait_for_server
+
+gpu_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+if gpu_count == 4:
+    cmd = (
+        "python -m sglang.launch_server "
+        "--model-path MiniMaxAI/MiniMax-M3 "
+        "--host 0.0.0.0 "
+        "--port 8000 "
+        "--tp-size 4 "
+        "--tool-call-parser minimax-m2 "
+        "--reasoning-parser minimax-append-think "
+        "--trust-remote-code "
+        "--mem-fraction-static 0.85"
+    )
+elif gpu_count == 8:
+    cmd = (
+        "python -m sglang.launch_server "
+        "--model-path MiniMaxAI/MiniMax-M3 "
+        "--host 0.0.0.0 "
+        "--port 8000 "
+        "--tp-size 8 "
+        "--ep-size 8 "
+        "--tool-call-parser minimax-m2 "
+        "--reasoning-parser minimax-append-think "
+        "--trust-remote-code "
+        "--mem-fraction-static 0.85"
+    )
+else:
+    raise RuntimeError(f"建议使用 4 或 8 张 GPU，当前检测到: {gpu_count}")
+
+server_process, port = launch_server_cmd(cmd, port=8000)
+wait_for_server(f"http://127.0.0.1:{port}")
+print(f"SGLang Server started: http://127.0.0.1:{port}")
+```
+
+启动：
+
+```bash
+python start_server.py
+```
+
+服务启动成功后将监听 `http://127.0.0.1:8000/v1`。
+
+### 命令行直接启动
+
+4 卡部署：
+
+```bash
+python -m sglang.launch_server \
+  --model-path MiniMaxAI/MiniMax-M3 \
+  --tp-size 4 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --host 0.0.0.0 \
+  --trust-remote-code \
+  --port 8000 \
+  --mem-fraction-static 0.85
+```
+
+8 卡部署：
+
+```bash
+python -m sglang.launch_server \
+  --model-path MiniMaxAI/MiniMax-M3 \
+  --tp-size 8 \
+  --ep-size 8 \
+  --tool-call-parser minimax-m2 \
+  --trust-remote-code \
+  --host 0.0.0.0 \
+  --reasoning-parser minimax-append-think \
+  --port 8000 \
+  --mem-fraction-static 0.85
+```
+
+> 由于模型较大，首次加载时间较长，可能需要半小时以上。
+
+## curl 测试
+
+使用 curl 调用 OpenAI 兼容接口：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-M3",
+    "messages": [
+      {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+      {"role": "user", "content": [{"type": "text", "text": "请简要介绍 MiniMax-M3 模型的特点。"}]}
+    ]
+  }'
+```
+
+## 调用示例
+
+以下示例均使用 OpenAI 官方 Python SDK 调用 SGLang 的 OpenAI 兼容接口。
+
+### 聊天对话（Chat Completions）
+
+```python
+# test_chat.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[
+        {"role": "user", "content": "请介绍 MiniMax-M3 相比 M2.5 有哪些提升？"}
+    ],
+    max_tokens=8192,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+msg = response.choices[0].message
+print("MiniMax-M3:", msg.content)
+```
+
+运行：
+
+```bash
+python test_chat.py
+```
+
+### 流式输出（Streaming）
+
+```python
+# test_streaming.py
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="EMPTY",
+    base_url="http://127.0.0.1:8000/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[{"role": "user", "content": "请用 Python 实现一个二叉搜索树，包含插入、查找和删除操作。"}],
+    stream=True,
+    max_tokens=32768,
+    top_p=0.95,
+    temperature=1.0,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta and delta.content:
+        print(delta.content, end="", flush=True)
+```
+
+运行：
+
+```bash
+python test_streaming.py
+```
+
+### 图片输入（Vision）
+
+MiniMax-M3 原生支持图片输入。在 OpenAI 兼容接口中，将 `image_url` 与文本一起放入 `content` 数组即可：
+
+```python
+# test_vision.py
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:8000/v1")
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M3",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "请描述这张图片中的内容。"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg"},
+                },
+            ],
+        }
+    ],
+    max_tokens=4096,
+)
+print(response.choices[0].message.content)
+```
+
+> 仅支持图片输入；视频、音频、文档暂不支持。
+
+### 工具调用（Tool Calling）
+
+MiniMax-M3 在 Agent 和工具调用方面继续保持强表现。在 SGLang 部署时通过 `--tool-call-parser minimax-m2` 启用工具调用功能。
+
+```python
+# test_tool_calling.py
+from openai import OpenAI
+import json
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+def get_weather(location: str, unit: str):
+    return f"Getting the weather for {location} in {unit}..."
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City and state, e.g., 'San Francisco, CA'"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location", "unit"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model=client.models.list().data[0].id,
+    messages=[{"role": "user", "content": "北京今天天气怎么样？请用摄氏度。"}],
+    tools=tools,
+    tool_choice="auto"
+)
+
+tool_call = response.choices[0].message.tool_calls[0].function
+print(f"Function called: {tool_call.name}")
+print(f"Arguments: {tool_call.arguments}")
+print(f"Result: {get_weather(**json.loads(tool_call.arguments))}")
+```
+
+运行：
+
+```bash
+python test_tool_calling.py
+```
+
+## 参数说明与建议
+
+- `--model-path`：模型名称或本地路径（例：`MiniMaxAI/MiniMax-M3`）。
+- `--tp-size`：张量并行大小，常设为 GPU 数量（4 或 8）。
+- `--ep-size`：专家并行大小（8 卡示例中开启）。
+- `--tool-call-parser minimax-m2`：启用 MiniMax 的工具调用解析。
+- `--reasoning-parser minimax-append-think`：启用思考内容解析。
+- `--mem-fraction-static`：静态显存比例，显存紧张时可适当调低。
+- `--trust-remote-code`：信任远程代码（MiniMax 模型需要此参数）。
+- 官方推荐采样参数：temperature=1.0, top_p=0.95, top_k=20。
+- M3 单次最大输出可达 128K token；按业务需要设置 `max_tokens`。
+
+> 显存建议：M3 权重约 220 GB；每 1M 上下文约 240 GB。请结合业务并发与上下文需求评估资源。
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+如果遇到网络问题，可设置镜像后再进行拉取：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+### MiniMax-M3 model is not currently supported
+
+请升级到最新的稳定版本：
+
+```bash
+pip install -U sglang
+```
+
+## 参考链接
+
+- [MiniMax-M3 GitHub](https://github.com/MiniMax-AI/MiniMax-M3)
+- [MiniMax-M3 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M3)
+- [MiniMax 平台文档](https://platform.minimax.io/docs/guides/text-generation)
+- [SGLang 官方文档](https://github.com/sgl-project/sglang)

--- a/models/MiniMax-M3/3-MiniMax-M3-Transformers.md
+++ b/models/MiniMax-M3/3-MiniMax-M3-Transformers.md
@@ -1,0 +1,166 @@
+# MiniMax-M3 Transformers 部署调用
+
+## MiniMax-M3 简介
+
+[MiniMax-M3](https://github.com/MiniMax-AI/MiniMax-M3) 是 MiniMax 推出的最新一代开源大语言模型。相较于 M2.5，M3 在长上下文、推理质量和多模态能力上均有明显提升：上下文窗口扩展到 **512K**、单次最大输出可达 **128K**，并原生支持**图片输入**（仅图片，视频/音频/文档暂不支持）。本文演示如何通过 Transformers 直接加载并运行 MiniMax-M3 模型。
+
+## 环境准备
+
+基础环境（参考值）：
+
+- OS：Linux
+- Python：3.9 - 3.12
+- Transformers：>= 4.57.1
+- GPU：compute capability 7.0 or higher，显存需求约 220 GB
+
+安装依赖：
+
+> 建议使用虚拟环境（venv / conda / uv）避免依赖冲突
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install transformers==4.57.1 torch accelerate --torch-backend=auto
+```
+
+## 模型下载
+
+Transformers 会在首次加载时自动从 Hugging Face 下载并缓存模型。若网络受限，可使用 `modelscope` 提前下载：
+
+```python
+# model_download.py
+from modelscope import snapshot_download
+
+model_dir = snapshot_download('MiniMaxAI/MiniMax-M3', cache_dir='/root/autodl-tmp', revision='master')
+print(f"模型下载成功，保存到: {model_dir}")
+```
+
+```bash
+pip install modelscope
+python model_download.py
+```
+
+> 注意：使用 `modelscope` 下载模型时无需设置 HF 镜像。若不使用 modelscope，而是直接通过 Transformers 从 Hugging Face 下载，网络受限时可设置镜像：`export HF_ENDPOINT=https://hf-mirror.com`
+
+## 推理示例
+
+### 基础对话
+
+```python
+# test_transformers.py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+MODEL_PATH = "MiniMaxAI/MiniMax-M3"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_PATH,
+    device_map="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+messages = [
+    {"role": "user", "content": [{"type": "text", "text": "请介绍一下 MiniMax-M3 模型的主要特点。"}]},
+]
+
+model_inputs = tokenizer.apply_chat_template(
+    messages, return_tensors="pt", add_generation_prompt=True
+).to("cuda")
+
+generated_ids = model.generate(
+    model_inputs,
+    max_new_tokens=2048,
+    generation_config=model.generation_config,
+)
+
+response = tokenizer.batch_decode(generated_ids)[0]
+print(response)
+```
+
+运行：
+
+```bash
+python test_transformers.py
+```
+
+### 多轮对话
+
+```python
+# test_multi_turn.py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_PATH = "MiniMaxAI/MiniMax-M3"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_PATH,
+    device_map="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+messages = [
+    {"role": "user", "content": [{"type": "text", "text": "什么是快速排序？"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "快速排序是一种高效的排序算法，采用分治策略，通过选择一个基准元素将数组分为两部分，然后递归排序。"}]},
+    {"role": "user", "content": [{"type": "text", "text": "请用 Python 实现它。"}]},
+]
+
+model_inputs = tokenizer.apply_chat_template(
+    messages, return_tensors="pt", add_generation_prompt=True
+).to("cuda")
+
+generated_ids = model.generate(
+    model_inputs,
+    max_new_tokens=2048,
+    generation_config=model.generation_config,
+)
+
+response = tokenizer.batch_decode(generated_ids)[0]
+print(response)
+```
+
+运行：
+
+```bash
+python test_multi_turn.py
+```
+
+### 长输出（≤128K）
+
+M3 支持单次最大 128K 的输出长度，按需调整 `max_new_tokens` 即可：
+
+```python
+generated_ids = model.generate(
+    model_inputs,
+    max_new_tokens=131072,   # 128K
+    generation_config=model.generation_config,
+)
+```
+
+> 输出越长，显存与时延越高，建议结合任务实际需求设置。
+
+## 常见问题
+
+### Hugging Face 网络问题
+
+若未使用 `modelscope` 下载模型，而是直接通过 Transformers 从 Hugging Face 下载，可设置镜像：
+
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+```
+
+> 若已通过 `modelscope` 下载模型并指定了本地路径，则无需此设置。
+
+### MiniMax-M3 model is not currently supported
+
+请确认已开启 `trust_remote_code=True`，并升级 Transformers 至 >= 4.57.1：
+
+```bash
+pip install -U transformers
+```
+
+## 参考链接
+
+- [MiniMax-M3 GitHub](https://github.com/MiniMax-AI/MiniMax-M3)
+- [MiniMax-M3 HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M3)
+- [MiniMax 平台文档](https://platform.minimax.io/docs/guides/text-generation)

--- a/support_model.md
+++ b/support_model.md
@@ -8,6 +8,7 @@
 - [Step-3.5-Flash](#step-35-flash)
 - [GLM-4.7-Flash](#glm-47-flash)
 - [谷歌-Gemma3](#谷歌-gemma3)
+- [MiniMax-M3](#minimax-m3)
 - [MiniMax-M2.5](#minimax-m25)
 - [MiniMax-M2](#minimax-m2)
 - [Qwen3-VL-4B-Instruct](#qwen3-vl-4b-instruct)
@@ -91,6 +92,16 @@
 - [x] [gemma-2b-it Peft Lora 微调 ](./models/Gemma/04-Gemma-2B-Instruct%20Lora微调.md) @陈榆
 - [X] [gemma3-4b-it AMD 环境准备](./models/Gemma3/7-gemma3-4b-it%20AMD环境准备.md) @陈榆
 - [X] [gemma3-4b-it AMD 模型服务部署](./models/Gemma3/8-gemma3-4b-it%20模型服务部署.md) @陈榆
+
+### MiniMax-M3
+
+[MiniMax-M3](https://github.com/MiniMax-AI/MiniMax-M3)
+- [x] [MiniMax-M3 在线体验地址](https://agent.minimax.io/)
+- [x] [MiniMax-M3 Hugging Face 地址](https://huggingface.co/MiniMaxAI/MiniMax-M3)
+- [x] [MiniMax-M3 Text Generation Guide](https://platform.minimax.io/docs/guides/text-generation)
+- [x] [MiniMax-M3 vLLM 部署调用](./models/MiniMax-M3/1-MiniMax-M3-vLLM.md)
+- [x] [MiniMax-M3 SGLang 部署调用](./models/MiniMax-M3/2-MiniMax-M3-SGLang.md)
+- [x] [MiniMax-M3 Transformers 部署调用](./models/MiniMax-M3/3-MiniMax-M3-Transformers.md)
 
 ### MiniMax-M2.5
 


### PR DESCRIPTION
## 新增 MiniMax-M3 部署教程

### 概要

新增 MiniMax-M3 模型的部署教程，包括 vLLM、SGLang 和 Transformers 三种部署方式的完整指南。

[MiniMax-M3](https://github.com/MiniMax-AI/MiniMax-M3) 是 MiniMax 推出的最新一代开源大语言模型。相较于 M2.5，主要升级包括：

- **超长上下文**：上下文窗口扩展到 **512K** token
- **更长单次输出**：单次最大输出可达 **128K** token
- **原生支持图片输入**：OpenAI 兼容和 Anthropic 兼容两套接口均可使用图片输入（仅图片，视频/音频/文档暂不支持）

### 变更内容

**新增文件：**
- `models/MiniMax-M3/1-MiniMax-M3-vLLM.md`
- `models/MiniMax-M3/2-MiniMax-M3-SGLang.md`
- `models/MiniMax-M3/3-MiniMax-M3-Transformers.md`

**更新文件：**
- `support_model.md`：目录与"已支持模型列表"中新增 MiniMax-M3 入口
- `README.md`：已支持模型表格中新增 MiniMax-M3 链接
- `README_en.md`：Supported Models 表格中新增 MiniMax-M3 链接

**保留：** MiniMax-M2.5、MiniMax-M2 的现有教程不变，作为历史档案继续保留。

### 教程内容

每个 M3 部署教程涵盖：
- 模型简介、环境准备与显存配置建议
- 通过 Hugging Face / modelscope 下载模型
- 服务启动（多卡部署：4 卡 / 8 卡）
- curl 与 OpenAI SDK 调用示例
- 流式输出、工具调用（Tool Calling）、**图片输入（Vision）** 示例
- 参数说明与常见问题排查

### 兼容性

- 沿用 M2.5 教程的成熟结构，便于熟悉 M2.5 教程的读者无缝迁移到 M3
- 保留 M2.5 与 M2 的所有原有教程，不影响存量用户
- 在表格与目录中将 M3 置于 MiniMax 系列首位，作为推荐入门版本

### 致谢

感谢 [@姜舒凡](https://github.com/Tsumugii24)、[@王泽宇](https://github.com/yzWang121) 等社区贡献者完成的 MiniMax-M2 / M2.5 系列教程，本次 M3 教程在其基础上进行延展。