### PR TITLE
docs: add MiniMax-M2.7 deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
       • <a href="./support_model.md#glm-47-flash">GLM-4.7-Flash</a><br>
       • <a href="./support_model.md#gemma3">Gemma3</a><br>
       • <a href="./support_model.md#minimax-m3">MiniMax-M3</a><br>
+      • <a href="./support_model.md#minimax-m27">MiniMax-M2.7</a><br>
       • <a href="./support_model.md#minimax-m25">MiniMax-M2.5</a><br>
       • <a href="./support_model.md#minimax-m2">MiniMax-M2</a><br>
       • <a href="./support_model.md#qwen3">Qwen3</a><br>

--- a/README_en.md
+++ b/README_en.md
@@ -92,6 +92,7 @@
       • <a href="./support_model.md#glm-47-flash">GLM-4.7-Flash</a><br>
       • <a href="./support_model.md#gemma3">Gemma3</a><br>
       • <a href="./support_model.md#minimax-m3">MiniMax-M3</a><br>
+      • <a href="./support_model.md#minimax-m27">MiniMax-M2.7</a><br>
       • <a href="./support_model.md#minimax-m25">MiniMax-M2.5</a><br>
       • <a href="./support_model.md#minimax-m2">MiniMax-M2</a><br>
       • <a href="./support_model.md#qwen3">Qwen3</a><br>

--- a/models/MiniMax-M2.7/1-MiniMax-M2.7-vLLM.md
+++ b/models/MiniMax-M2.7/1-MiniMax-M2.7-vLLM.md
@@ -1,0 +1,55 @@
+# MiniMax-M2.7 vLLM Deployment Guide
+
+This guide serves [MiniMax-M2.7](https://github.com/MiniMax-AI/MiniMax-M2.7) through an OpenAI-compatible vLLM endpoint. The model weights are available from [Hugging Face](https://huggingface.co/MiniMaxAI/MiniMax-M2.7).
+
+For the latest compatibility and hardware requirements, consult the [official vLLM deployment guide](https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/docs/vllm_deploy_guide.md). The official guide currently requires Linux, Python 3.9 through 3.12, a GPU with compute capability 7.0 or newer, and about 220 GB of memory for the weights.
+
+## Install vLLM
+
+Create an isolated environment and install the latest compatible vLLM release:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install vllm --torch-backend=auto
+```
+
+## Start the server
+
+For a four-GPU deployment:
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M2.7 --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+For an eight-GPU deployment with expert parallelism:
+
+```bash
+SAFETENSORS_FAST_GPU=1 vllm serve \
+    MiniMaxAI/MiniMax-M2.7 --trust-remote-code \
+    --enable_expert_parallel --tensor-parallel-size 8 \
+    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think
+```
+
+The server listens on `http://localhost:8000/v1` by default.
+
+## Verify the endpoint
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "MiniMaxAI/MiniMax-M2.7",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Explain mixture-of-experts models briefly."}
+        ]
+    }'
+```
+
+If vLLM reports that the model is unsupported, upgrade vLLM. If CUDA graph capture causes an illegal memory access, add `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'` to the server command, as recommended by the official guide.

--- a/models/MiniMax-M2.7/2-MiniMax-M2.7-SGLang.md
+++ b/models/MiniMax-M2.7/2-MiniMax-M2.7-SGLang.md
@@ -1,0 +1,62 @@
+# MiniMax-M2.7 SGLang Deployment Guide
+
+This guide serves [MiniMax-M2.7](https://github.com/MiniMax-AI/MiniMax-M2.7) through an OpenAI-compatible SGLang endpoint. The model weights are available from [Hugging Face](https://huggingface.co/MiniMaxAI/MiniMax-M2.7).
+
+For the latest compatibility and hardware requirements, consult the [official SGLang deployment guide](https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/docs/sglang_deploy_guide.md). The official guide currently requires Linux, Python 3.9 through 3.12, a GPU with compute capability 7.0 or newer, and about 220 GB of memory for the weights.
+
+## Install SGLang
+
+Create an isolated environment and install SGLang:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install sglang
+```
+
+Use SGLang 0.5.4.post1 or newer for MiniMax-M2 family support.
+
+## Start the server
+
+For a four-GPU deployment:
+
+```bash
+python -m sglang.launch_server \
+    --model-path MiniMaxAI/MiniMax-M2.7 \
+    --tp-size 4 \
+    --tool-call-parser minimax-m2 \
+    --reasoning-parser minimax-append-think \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    --port 8000 \
+    --mem-fraction-static 0.85
+```
+
+For an eight-GPU deployment with expert parallelism:
+
+```bash
+python -m sglang.launch_server \
+    --model-path MiniMaxAI/MiniMax-M2.7 \
+    --tp-size 8 \
+    --ep-size 8 \
+    --tool-call-parser minimax-m2 \
+    --reasoning-parser minimax-append-think \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    --port 8000 \
+    --mem-fraction-static 0.85
+```
+
+## Verify the endpoint
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "MiniMaxAI/MiniMax-M2.7",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Explain mixture-of-experts models briefly."}
+        ]
+    }'
+```

--- a/models/MiniMax-M2.7/3-MiniMax-M2.7-Transformers.md
+++ b/models/MiniMax-M2.7/3-MiniMax-M2.7-Transformers.md
@@ -1,0 +1,57 @@
+# MiniMax-M2.7 Transformers Deployment Guide
+
+This guide runs [MiniMax-M2.7](https://github.com/MiniMax-AI/MiniMax-M2.7) directly with Transformers. The model weights are available from [Hugging Face](https://huggingface.co/MiniMaxAI/MiniMax-M2.7).
+
+For the latest compatibility and hardware requirements, consult the [official Transformers deployment guide](https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/docs/transformers_deploy_guide.md). The official guide currently requires Linux, Python 3.9 through 3.12, Transformers 4.57.1, a GPU with compute capability 7.0 or newer, and about 220 GB of memory for the weights.
+
+## Install dependencies
+
+Create an isolated environment and install the tested Transformers release:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install transformers==4.57.1 torch accelerate --torch-backend=auto
+```
+
+## Run inference
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model_id = "MiniMaxAI/MiniMax-M2.7"
+
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    device_map="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "Explain mixture-of-experts models briefly.",
+            }
+        ],
+    }
+]
+
+model_inputs = tokenizer.apply_chat_template(
+    messages,
+    return_tensors="pt",
+    add_generation_prompt=True,
+).to("cuda")
+
+with torch.inference_mode():
+    generated_ids = model.generate(model_inputs, max_new_tokens=256)
+
+new_tokens = generated_ids[:, model_inputs.shape[1]:]
+print(tokenizer.batch_decode(new_tokens, skip_special_tokens=True)[0])
+```
+
+Keep `trust_remote_code=True`; the model depends on its repository implementation. If downloading from Hugging Face is unavailable on your network, configure an approved proxy or mirror before running the script.

--- a/support_model.md
+++ b/support_model.md
@@ -12,6 +12,7 @@
 - [GLM-4.7-Flash](#glm-47-flash)
 - [谷歌-Gemma3](#谷歌-gemma3)
 - [MiniMax-M3](#minimax-m3)
+- [MiniMax-M2.7](#minimax-m27)
 - [MiniMax-M2.5](#minimax-m25)
 - [MiniMax-M2](#minimax-m2)
 - [Qwen3-VL-4B-Instruct](#qwen3-vl-4b-instruct)
@@ -125,6 +126,16 @@
 - [x] [MiniMax-M3 vLLM 部署调用](./models/MiniMax-M3/1-MiniMax-M3-vLLM.md)
 - [x] [MiniMax-M3 SGLang 部署调用](./models/MiniMax-M3/2-MiniMax-M3-SGLang.md)
 - [x] [MiniMax-M3 Transformers 部署调用](./models/MiniMax-M3/3-MiniMax-M3-Transformers.md)
+
+### MiniMax-M2.7
+
+[MiniMax-M2.7](https://github.com/MiniMax-AI/MiniMax-M2.7)
+- [x] [MiniMax-M2.7 online experience](https://agent.minimax.io/)
+- [x] [MiniMax-M2.7 on Hugging Face](https://huggingface.co/MiniMaxAI/MiniMax-M2.7)
+- [x] [MiniMax-M2.7 text generation guide](https://platform.minimax.io/docs/guides/text-generation)
+- [x] [MiniMax-M2.7 vLLM deployment](./models/MiniMax-M2.7/1-MiniMax-M2.7-vLLM.md)
+- [x] [MiniMax-M2.7 SGLang deployment](./models/MiniMax-M2.7/2-MiniMax-M2.7-SGLang.md)
+- [x] [MiniMax-M2.7 Transformers deployment](./models/MiniMax-M2.7/3-MiniMax-M2.7-Transformers.md)
 
 ### MiniMax-M2.5
 


### PR DESCRIPTION
Reason: The support registry and deployment guides cover MiniMax-M3, MiniMax-M2.5, and MiniMax-M2, but do not include MiniMax-M2.7.

## Summary

- add concise MiniMax-M2.7 deployment guides for vLLM, SGLang, and Transformers
- link the new guides from the support registry
- add MiniMax-M2.7 to both repository model indexes

## Checks
- `git diff --check`
- Markdown fence and local-link validation
- Python and Bash snippet syntax validation
- English-only addition and secret scans